### PR TITLE
uuid認証ができないバグ修正

### DIFF
--- a/newloginsystem/src/apartkktrain/login/Main.php
+++ b/newloginsystem/src/apartkktrain/login/Main.php
@@ -47,11 +47,11 @@ class Main extends PluginBase implements Listener
     		$myip = $this->config2->get($name);
     		$myuuid = $this->config3->get($name);
 
-    		if ($myip === $ip) 
+    		if ($myip === $ip&&$myuuid === $uuid) 
     		{
-                if ($myuuid === $uuid) {
-                	$player->sendMessage("§a[NEW!LoginSystem]認証に成功しました。おかえりなさい!");
-                }
+                
+            $player->sendMessage("§a[NEW!LoginSystem]認証に成功しました。おかえりなさい!");
+                
     		}else{
     			$player->sendMessage("§4[NEWLoginSystem]認証に失敗しました。IPアドレスや端末変更された可能性がございます。\n/login password でもう一度ログインをお願いいたします。");
       		    $player->setImmobile();  			
@@ -92,6 +92,7 @@ class Main extends PluginBase implements Listener
             $sender->sendMessage("§a[LoginSystem]password・その他端末情報を保存し、正常にアカウント登録が完了しました。");
             $this->config->save();
             $this->config2->save();
+            $this->config3->save();
             return true;
             }
           }


### PR DESCRIPTION
uuid認証ができないバグの発生条件
・登録済みのユーザー
・ipアドレスは前回と変更ない
・uuidにのみ変更があった

このバグによる影響
ユーザー側には何もメッセージが送信されず、ユーザーは自分に何が起こっているか把握できない。

原因
ip認証を通した後にuuidでの認証をおこなっているが、uuid認証の例外処理がされていない。

修正点
・ip認証とuuid認証を同時に行うように変更。
・uuidが登録時に即コンフィグにセーブされるように変更。